### PR TITLE
Add support for tram stop by stop

### DIFF
--- a/src/templates/disruptionSignUp.dummyData.json
+++ b/src/templates/disruptionSignUp.dummyData.json
@@ -13,5 +13,8 @@
   "Trains": [
     { "To": "Birmingham New Street", "From": "Aston", "LineIds": ["Cross City", "Walsall", "Snow Hill"] },
     { "To": "Birmingham Snow Hill", "From": "Birmingham Snow Hill", "LineIds": [] }
+  ],
+  "TramLines": [
+    { "To":"Birmingham New Street", "From": "St Pauls" }
   ]
 }

--- a/src/templates/disruptionSignUp.mjml
+++ b/src/templates/disruptionSignUp.mjml
@@ -34,33 +34,36 @@
           </mj-text>
 
           <mj-raw>{% for item in Services %}</mj-raw>
-          <mj-raw>{% if item.Id != '4546' %} {% assign bus = true %} {% endif %}</mj-raw>
-          <mj-raw>{% if item.Id == '4546' %} {% assign fullTramLine = true %} {% endif %}</mj-raw>
+            <mj-raw>{% if item.Id != '4546' %} {% assign bus = true %} {% endif %}</mj-raw>
+            <mj-raw>{% if item.Id == '4546' %} {% assign fullTramLine = true %} {% endif %}</mj-raw>
           <mj-raw>{% endfor %} {% if bus %}</mj-raw>
           <mj-text padding-top="0px" padding-bottom="20px" font-weight="bold">Bus</mj-text>
 
           <mj-text padding-top="0px" padding-bottom="10px">
             <ul style="list-style-type: none; padding: 0; margin: 0">
               <mj-raw>{% for item in Services %}</mj-raw>
-              <mj-raw>{% if item.Id != '4546' %}</mj-raw>
-              <li style="padding-bottom: 20px">{{item.Name | upcase}} {{item.IdName}}</li>
-              <mj-raw>{% endif %}</mj-raw>
+                <mj-raw>{% if item.Id != '4546' %}</mj-raw>
+                  <li style="padding-bottom: 20px">{{item.Name | upcase}} {{item.IdName}}</li>
+                <mj-raw>{% endif %}</mj-raw>
               <mj-raw>{% endfor %}</mj-raw>
             </ul>
           </mj-text>
-          <mj-raw>{% endif %} {% if fullTramLine or TramLines.size > 0 %}</mj-raw>
-          <mj-text padding-top="0px" padding-bottom="20px" font-weight="bold">Tram</mj-text>
-          <mj-text padding-top="0px" padding-bottom="10px">
-            <ul style="list-style-type: none; padding: 0; margin: 0">
-              {% for item in Services %} {% if item.Id == '4546' %}
-              <li style="padding-bottom: 20px">{{item.Name | upcase}} {{item.IdName}}</li>
-              <mj-raw>{% endif %}</mj-raw>
-              <mj-raw>{% endfor %}</mj-raw>
-              <mj-raw>{% for item in TramLines %}</mj-raw>
-              <li style="padding-bottom: 20px">{{item.From}} to {{item.To}}</li>
-              {% endfor %}
-            </ul>
-          </mj-text>
+          <mj-raw>{% endif %}</mj-raw>
+
+          <mj-raw>{% if fullTramLine or TramLines.size > 0 %}</mj-raw>
+            <mj-text padding-top="0px" padding-bottom="20px" font-weight="bold">Tram</mj-text>
+            <mj-text padding-top="0px" padding-bottom="10px">
+              <ul style="list-style-type: none; padding: 0; margin: 0">
+                <mj-raw>{% for item in Services %}</mj-raw>
+                  <mj-raw>{% if item.Id == '4546' %}</mj-raw>
+                    <li style="padding-bottom: 20px">{{item.Name | upcase}} {{item.IdName}}</li>
+                  <mj-raw>{% endif %}</mj-raw>
+                <mj-raw>{% endfor %}</mj-raw>
+                <mj-raw>{% for item in TramLines %}</mj-raw>
+                  <li style="padding-bottom: 20px">{{item.From}} to {{item.To}}</li>
+                <mj-raw>{% endfor %}</mj-raw>
+              </ul>
+            </mj-text>
           <mj-raw>{% endif %}</mj-raw>
 
           <mj-raw>{% if Trains[0].LineIds != null %}</mj-raw>

--- a/src/templates/disruptionSignUp.mjml
+++ b/src/templates/disruptionSignUp.mjml
@@ -54,7 +54,9 @@
             <ul style="list-style-type: none; padding: 0; margin: 0">
               {% for item in Services %} {% if item.Id == '4546' %}
               <li style="padding-bottom: 20px">{{item.Name | upcase}} {{item.IdName}}</li>
-              {% endif %} {% endfor %} {% for item in TramLines %}
+              <mj-raw>{% endif %}</mj-raw>
+              <mj-raw>{% endfor %}</mj-raw>
+              <mj-raw>{% for item in TramLines %}</mj-raw>
               <li style="padding-bottom: 20px">{{item.From}} to {{item.To}}</li>
               {% endfor %}
             </ul>

--- a/src/templates/disruptionSignUp.mjml
+++ b/src/templates/disruptionSignUp.mjml
@@ -35,7 +35,7 @@
 
           <mj-raw>{% for item in Services %}</mj-raw>
           <mj-raw>{% if item.Id != '4546' %} {% assign bus = true %} {% endif %}</mj-raw>
-          <mj-raw>{% if item.Id == '4546' %} {% assign tram = true %} {% endif %}</mj-raw>
+          <mj-raw>{% if item.Id == '4546' %} {% assign fullTramLine = true %} {% endif %}</mj-raw>
           <mj-raw>{% endfor %} {% if bus %}</mj-raw>
           <mj-text padding-top="0px" padding-bottom="20px" font-weight="bold">Bus</mj-text>
 
@@ -48,13 +48,15 @@
               <mj-raw>{% endfor %}</mj-raw>
             </ul>
           </mj-text>
-          <mj-raw>{% endif %} {% if tram %}</mj-raw>
+          <mj-raw>{% endif %} {% if fullTramLine or TramLines.size > 0 %}</mj-raw>
           <mj-text padding-top="0px" padding-bottom="20px" font-weight="bold">Tram</mj-text>
           <mj-text padding-top="0px" padding-bottom="10px">
             <ul style="list-style-type: none; padding: 0; margin: 0">
               {% for item in Services %} {% if item.Id == '4546' %}
               <li style="padding-bottom: 20px">{{item.Name | upcase}} {{item.IdName}}</li>
-              {% endif %} {% endfor %}
+              {% endif %} {% endfor %} {% for item in TramLines %}
+              <li style="padding-bottom: 20px">{{item.From}} to {{item.To}}</li>
+              {% endfor %}
             </ul>
           </mj-text>
           <mj-raw>{% endif %}</mj-raw>


### PR DESCRIPTION
Add support for user selecting multiple tram stop ranges.

_The dummy data contains both a sign up to the full tram line and a range of tram stops, but on live it will be one or the other._